### PR TITLE
Revert default parameter override

### DIFF
--- a/packages/cocoapods/src/downloader/cache.ts
+++ b/packages/cocoapods/src/downloader/cache.ts
@@ -247,7 +247,6 @@ export class Cache {
     Executable.execute_command(
       "rsync",
       ["-a", "--exclude=.git", "--delete", `${source}/`, destination],
-      false,
     );
   }
 


### PR DESCRIPTION
Watching the steam back, it looks like you mistakenly kept this set to false while you added the default parameter value